### PR TITLE
Actually use matrix_synapse_storage_path

### DIFF
--- a/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
+++ b/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
@@ -43,7 +43,7 @@ ExecStart=/usr/bin/docker run --rm --name matrix-synapse \
 			{% endif %}
 			-v {{ matrix_synapse_config_dir_path }}:/data:ro \
 			-v {{ matrix_synapse_run_path }}:/matrix-run:rw \
-			-v {{ matrix_synapse_base_path }}/storage:/matrix-media-store-parent:slave \
+			-v {{ matrix_synapse_storage_path }}:/matrix-media-store-parent:slave \
 			{% for volume in matrix_synapse_container_additional_volumes %}
 			-v {{ volume.src }}:{{ volume.dst }}:{{ volume.options }} \
 			{% endfor %}


### PR DESCRIPTION
`matrix_synapse_storage_path` is already defined in `matrix-synapse/defaults/main.yml` (with a default of `"{{ matrix_synapse_base_path }}/storage"`), but was not being used for its presumed purpose in `matrix-synapse.service.j2`. As a result, if `matrix_synapse_storage_path` was overridden (in a `vars.yml`), the synapse service failed to start.